### PR TITLE
Remove DataModel, UIModel and DomainModel

### DIFF
--- a/data/src/main/java/com/mutualmobile/praxis/data/mapper/EntityMapper.kt
+++ b/data/src/main/java/com/mutualmobile/praxis/data/mapper/EntityMapper.kt
@@ -1,11 +1,7 @@
 package com.mutualmobile.praxis.data.mapper
 
-import com.mutualmobile.praxis.domain.mappers.DomainModel
-
-interface EntityMapper<M : DomainModel, ME : DataModel> {
+interface EntityMapper<M, ME> {
   fun mapToDomain(entity: ME): M
 
   fun mapToData(model: M): ME
 }
-
-open class DataModel

--- a/domain/src/main/java/com/mutualmobile/praxis/domain/mappers/DomainModel.kt
+++ b/domain/src/main/java/com/mutualmobile/praxis/domain/mappers/DomainModel.kt
@@ -1,10 +1,6 @@
 package com.mutualmobile.praxis.domain.mappers
 
-open class DomainModel
-
-open class UIModel
-
-interface UiModelMapper<M : DomainModel, MI : UIModel> {
+interface UiModelMapper<M, MI> {
   fun mapToPresentation(model: M): MI
 
   fun mapToDomain(modelItem: MI): M


### PR DESCRIPTION
This PR addresses the following issues: https://github.com/mutualmobile/Praxis/issues/41, https://github.com/mutualmobile/Praxis/issues/42 and removes DataModel, UIModel and DomainModel open classes since they're not required anymore.