### PR TITLE
Update dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
   id(BuildPlugins.KOTLIN_PARCELABLE_PLUGIN)
   id(BuildPlugins.KOTLIN_KAPT)
   id(BuildPlugins.DAGGER_HILT)
-  id(BuildPlugins.ktLint)
+  id(BuildPlugins.ktLint) version "11.2.0"
 }
 
 // def preDexEnabled = "true" == System.getProperty("pre-dex", "true")
@@ -75,14 +75,11 @@ android {
 
   buildFeatures {
     dataBinding = true
-  }
-
-  buildFeatures {
     compose = true
   }
 
   composeOptions {
-    kotlinCompilerExtensionVersion = Lib.Androidx.composeVersion
+    kotlinCompilerExtensionVersion = Lib.Androidx.Compose.composeCompilerVersion
   }
 
   packagingOptions {
@@ -93,18 +90,17 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
   }
 
   kotlinOptions {
-    jvmTarget = "1.8"
+    jvmTarget = "11"
   }
 }
 
 // Required for annotation processing plugins like Dagger
 kapt {
-  generateStubs = true
   correctErrorTypes = true
 }
 
@@ -125,6 +121,7 @@ dependencies {
   
 
   Lib.Androidx.list.forEach(::api)
+  implementation(platform(Lib.Androidx.Compose.COMPOSE_BOM))
   Lib.Androidx.Compose.list.forEach(::api)
   Lib.ThirdParty.list.forEach(::api)
   Lib.Accompanist.list.forEach(::api)
@@ -142,7 +139,7 @@ dependencies {
   /*DI*/
   api(Lib.Di.hilt)
   api(Lib.Di.hiltNavigationCompose)
-  api(Lib.Di.viewmodel)
+//  api(Lib.Di.viewmodel)
   kapt(Lib.Di.hiltCompiler)
   kapt(Lib.Di.hiltAndroidCompiler)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,6 @@ buildscript {
     classpath(BuildPlugins.SAFE_ARGS_GRADLE_PLUGIN)
     classpath(BuildPlugins.DAGGER_HILT_PLUGIN)
     classpath(BuildPlugins.KOTLIN_GRADLE_PLUGIN)
-    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10")
     // NOTE: Do not place your application dependencies here; they belong
     // in the individual module build.gradle files
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,9 +10,7 @@ buildscript {
     classpath(BuildPlugins.SAFE_ARGS_GRADLE_PLUGIN)
     classpath(BuildPlugins.DAGGER_HILT_PLUGIN)
     classpath(BuildPlugins.KOTLIN_GRADLE_PLUGIN)
-    classpath(kotlin("serialization", version = Lib.Kotlin.KOTLIN_VERSION))
-    classpath(BuildPlugins.KTLINT_GRADLE_PLUGIN)
-    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10")
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10")
     // NOTE: Do not place your application dependencies here; they belong
     // in the individual module build.gradle files
   }

--- a/buildSrc/src/main/kotlin/AppVersions.kt
+++ b/buildSrc/src/main/kotlin/AppVersions.kt
@@ -1,13 +1,13 @@
 object AppVersions {
   private const val versionMajor = 1
   private const val versionMinor = 0
-  private const val versionPatch = 0
+  private const val versionPatch = 1
 
   const val versionCode = versionMajor * 10000 + versionMinor * 100 + versionPatch
   const val versionName = "$versionMajor.$versionMinor.$versionPatch"
 
-  const val COMPILE_SDK = 31
+  const val COMPILE_SDK = 33
   const val MIN_SDK = 21
-  const val TARGET_SDK = 31
+  const val TARGET_SDK = 33
   const val APPLICATION_ID = "com.mutualmobile.praxis"
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,7 +1,7 @@
 /** This file contains versions of all the dependencies used in the module  */
 
 object BuildPlugins {
-  private const val TOOLS_BUILD = "7.1.1"
+  private const val TOOLS_BUILD = "7.4.1"
   private const val KT_LINT = "9.2.1"
   private const val SAFE_ARGS = "2.3.5"
 
@@ -9,8 +9,8 @@ object BuildPlugins {
   const val KTLINT_GRADLE_PLUGIN = "org.jlleitschuh.gradle:ktlint-gradle:${KT_LINT}"
   const val SAFE_ARGS_GRADLE_PLUGIN =
     "androidx.navigation:navigation-safe-args-gradle-plugin:${SAFE_ARGS}"
-  const val DAGGER_HILT_PLUGIN = "com.google.dagger:hilt-android-gradle-plugin:2.38.1"
-  const val KOTLIN_GRADLE_PLUGIN = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
+  const val DAGGER_HILT_PLUGIN = "com.google.dagger:hilt-android-gradle-plugin:2.45"
+  const val KOTLIN_GRADLE_PLUGIN = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10"
   const val ANDROID_APPLICATION_PLUGIN = "com.android.application"
   const val ANDROID_LIBRARY_PLUGIN = "com.android.library"
   const val KOTLIN_ANDROID_PLUGIN = "kotlin-android"
@@ -23,21 +23,20 @@ object BuildPlugins {
 
 object Lib {
   object Kotlin {
-    const val KOTLIN_VERSION = "1.6.0"
-    private const val KTX_CORE_VERSION = "1.2.0"
-    const val KT_STD = "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${KOTLIN_VERSION}"
+    const val COROUTINE_VERSION = "1.6.4"
+    private const val KTX_CORE_VERSION = "1.9.0"
     private const val KTX_CORE = "androidx.core:core-ktx:${KTX_CORE_VERSION}"
-    private const val DATE_TIME = "org.jetbrains.kotlinx:kotlinx-datetime:0.3.2"
+    private const val DATE_TIME = "org.jetbrains.kotlinx:kotlinx-datetime:0.4.0"
 
-    const val COROUTINES = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${KOTLIN_VERSION}"
+    const val COROUTINES = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${COROUTINE_VERSION}"
     private const val COROUTINES_ANDROID =
-      "org.jetbrains.kotlinx:kotlinx-coroutines-android:${KOTLIN_VERSION}"
+      "org.jetbrains.kotlinx:kotlinx-coroutines-android:${COROUTINE_VERSION}"
 
-    val list = listOf(KT_STD, KTX_CORE, DATE_TIME, COROUTINES, COROUTINES_ANDROID)
+    val list = listOf(KTX_CORE, DATE_TIME, COROUTINES, COROUTINES_ANDROID)
   }
 
   object Google {
-    const val MATERIAL_DESIGN = "com.google.android.material:material:1.4.0"
+    const val MATERIAL_DESIGN = "com.google.android.material:material:1.8.0"
 
     val list = listOf(
       MATERIAL_DESIGN,
@@ -47,9 +46,9 @@ object Lib {
 
   object Androidx {
     // Compose
-    const val composeVersion = "1.1.0"
+    const val composeVersion = "1.4.2"
     private const val SPLASH_SCREEN_API = "androidx.core:core-splashscreen:1.0.0-beta01"
-    private const val APP_COMPAT = "androidx.appcompat:appcompat:1.3.0-beta01"
+    private const val APP_COMPAT = "androidx.appcompat:appcompat:1.6.1"
 
     val list = listOf(
       APP_COMPAT,
@@ -57,16 +56,20 @@ object Lib {
     )
 
     object Compose {
-      private const val ACTIVITY_COMPOSE = "androidx.activity:activity-compose:${composeVersion}"
+      const val composeCompilerVersion = "1.4.2"
+      const val bomVersion = "2023.01.00"
+
+      const val COMPOSE_BOM = "androidx.compose:compose-bom:$bomVersion"
+      private const val ACTIVITY_COMPOSE = "androidx.activity:activity-compose"
       private const val CONSTRAINT_LAYOUT_COMPOSE =
-        "androidx.constraintlayout:constraintlayout-compose:1.0.0"
-      private const val COMPOSE_UI = "androidx.compose.ui:ui:${composeVersion}"
+        "androidx.constraintlayout:constraintlayout-compose:1.0.1"
+      private const val COMPOSE_UI = "androidx.compose.ui:ui"
       private const val COMPOSE_LIVEDATA =
-        "androidx.compose.runtime:runtime-livedata:${composeVersion}"
-      private const val COMPOSE_MATERIAL = "androidx.compose.material:material:${composeVersion}"
-      private const val COMPOSE_TOOLING = "androidx.compose.ui:ui-tooling-preview:${composeVersion}"
-      private const val COMPOSE_DEBUG_TOOLING = "androidx.compose.ui:ui-tooling:${composeVersion}"
-      private const val COMPOSE_NAVIGATION = "androidx.navigation:navigation-compose:2.5.0-alpha01"
+        "androidx.compose.runtime:runtime-livedata"
+      private const val COMPOSE_MATERIAL = "androidx.compose.material:material"
+      private const val COMPOSE_TOOLING = "androidx.compose.ui:ui-tooling-preview"
+      private const val COMPOSE_DEBUG_TOOLING = "androidx.compose.ui:ui-tooling"
+      private const val COMPOSE_NAVIGATION = "androidx.navigation:navigation-compose:2.5.3"
 
       val list = listOf(
         CONSTRAINT_LAYOUT_COMPOSE,
@@ -83,20 +86,20 @@ object Lib {
 
 
   object Accompanist {
-    const val insets = "com.google.accompanist:accompanist-insets:0.23.0"
-    const val pager = "com.google.accompanist:accompanist-pager:0.23.0"
-    const val pagerIndicators = "com.google.accompanist:accompanist-pager-indicators:0.23.0"
+    const val insets = "com.google.accompanist:accompanist-insets:0.28.0"
+    const val pager = "com.google.accompanist:accompanist-pager:0.28.0"
+    const val pagerIndicators = "com.google.accompanist:accompanist-pager-indicators:0.28.0"
     const val systemuicontroller =
-      "com.google.accompanist:accompanist-systemuicontroller:0.23.0"
+      "com.google.accompanist:accompanist-systemuicontroller:0.28.0"
     val list = listOf(insets, pager, pagerIndicators, systemuicontroller)
   }
 
   object Di {
-    private const val DAGGER_VERSION = "2.40.5"
+    private const val DAGGER_VERSION = "2.45"
     const val hilt = "com.google.dagger:hilt-android:${DAGGER_VERSION}"
     const val hiltAndroidCompiler = "com.google.dagger:hilt-android-compiler:${DAGGER_VERSION}"
 
-    const val viewmodel = "androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03"
+//    const val viewmodel = "androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03"
     const val hiltCompiler = "androidx.hilt:hilt-compiler:1.0.0"
     const val hiltNavigationCompose = "androidx.hilt:hilt-navigation-compose:1.0.0-rc01"
   }
@@ -109,7 +112,7 @@ object Lib {
   }
 
   object Room {
-    private const val roomVersion = "2.4.1"
+    private const val roomVersion = "2.5.0"
     const val roomRuntime = "androidx.room:room-runtime:$roomVersion"
     const val roomCompiler = "androidx.room:room-compiler:$roomVersion"
     const val roomKtx = "androidx.room:room-ktx:$roomVersion"
@@ -134,17 +137,17 @@ object Lib {
 
 object UnitTesting {
   const val junit = "junit:junit:4.13.2"
-  const val MOCKK = "io.mockk:mockk:1.10.5"
-  const val coroutineTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0"
-  const val turbin = "app.cash.turbine:turbine:0.7.0"
+  const val MOCKK = "io.mockk:mockk:1.13.4"
+  const val coroutineTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Lib.Kotlin.COROUTINE_VERSION}"
+  const val turbin = "app.cash.turbine:turbine:0.12.1"
 
   val list = listOf(junit, MOCKK, coroutineTest, turbin)
 }
 
 object DevDependencies {
-  private const val LEAK_CANARY_VERSION = "2.8.1"
+  private const val LEAK_CANARY_VERSION = "2.10"
   const val LEAK_CANARY = "com.squareup.leakcanary:leakcanary-android:${LEAK_CANARY_VERSION}"
-  private const val TIMBER_VERSION = "4.7.1"
+  private const val TIMBER_VERSION = "5.0.1"
   const val TIMBER = "com.jakewharton.timber:timber:${TIMBER_VERSION}"
   val debugList = listOf(LEAK_CANARY)
   val list = listOf(TIMBER)

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id(BuildPlugins.KOTLIN_PARCELABLE_PLUGIN)
     id(BuildPlugins.KOTLIN_KAPT)
     id(BuildPlugins.DAGGER_HILT)
-    id(BuildPlugins.ktLint)
+    id(BuildPlugins.ktLint) version "11.2.0"
 }
 
 android {
@@ -26,7 +26,6 @@ android {
 
 // Required for annotation processing plugins like Dagger
 kapt {
-    generateStubs = true
     correctErrorTypes = true
 }
 
@@ -34,6 +33,7 @@ dependencies {
     
 
     Lib.Androidx.list.forEach(::implementation)
+    implementation(platform(Lib.Androidx.Compose.COMPOSE_BOM))
     Lib.Androidx.Compose.list.forEach(::implementation)
     Lib.ThirdParty.list.forEach(::implementation)
     Lib.Accompanist.list.forEach(::implementation)
@@ -43,7 +43,7 @@ dependencies {
     /*DI*/
     implementation(Lib.Di.hilt)
     implementation(Lib.Di.hiltNavigationCompose)
-    implementation(Lib.Di.viewmodel)
+//    implementation(Lib.Di.viewmodel)
     kapt(Lib.Di.hiltCompiler)
     kapt(Lib.Di.hiltAndroidCompiler)
 

--- a/commonui/build.gradle.kts
+++ b/commonui/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id(BuildPlugins.KOTLIN_PARCELABLE_PLUGIN)
     id(BuildPlugins.KOTLIN_KAPT)
     id(BuildPlugins.DAGGER_HILT)
-    id(BuildPlugins.ktLint)
+    id(BuildPlugins.ktLint) version "11.2.0"
 }
 
 android {
@@ -38,7 +38,6 @@ android {
 
 // Required for annotation processing plugins like Dagger
 kapt {
-    generateStubs = true
     correctErrorTypes = true
 }
 
@@ -46,6 +45,7 @@ dependencies {
     
 
     Lib.Androidx.list.forEach(::implementation)
+    implementation(platform(Lib.Androidx.Compose.COMPOSE_BOM))
     Lib.Androidx.Compose.list.forEach(::implementation)
     Lib.ThirdParty.list.forEach(::implementation)
     Lib.Accompanist.list.forEach(::implementation)
@@ -55,7 +55,7 @@ dependencies {
     /*DI*/
     implementation(Lib.Di.hilt)
     implementation(Lib.Di.hiltNavigationCompose)
-    implementation(Lib.Di.viewmodel)
+//    implementation(Lib.Di.viewmodel)
     kapt(Lib.Di.hiltCompiler)
     kapt(Lib.Di.hiltAndroidCompiler)
 

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -24,7 +24,6 @@ android {
 
 // Required for annotation processing plugins like Dagger
 kapt {
-  generateStubs = true
   correctErrorTypes = true
 }
 
@@ -37,7 +36,7 @@ dependencies {
   /*DI*/
   implementation(Lib.Di.hilt)
   implementation(Lib.Di.hiltNavigationCompose)
-  implementation(Lib.Di.viewmodel)
+//  implementation(Lib.Di.viewmodel)
   kapt(Lib.Di.hiltCompiler)
   kapt(Lib.Di.hiltAndroidCompiler)
 

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -9,7 +9,6 @@ java {
 }
 
 dependencies {
-  api(Lib.Kotlin.KT_STD)
   api(Lib.Kotlin.COROUTINES)
   implementation(Lib.Paging.PAGING_COMMON)
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jan 27 08:55:19 IST 2022
+#Fri Feb 17 01:50:43 IST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/navigator/build.gradle.kts
+++ b/navigator/build.gradle.kts
@@ -36,7 +36,6 @@ android {
 
 // Required for annotation processing plugins like Dagger
 kapt {
-  generateStubs = true
   correctErrorTypes = true
 }
 
@@ -45,6 +44,7 @@ dependencies {
   
 
   Lib.Androidx.list.forEach(::implementation)
+  implementation(platform(Lib.Androidx.Compose.COMPOSE_BOM))
   Lib.Androidx.Compose.list.forEach(::implementation)
   Lib.ThirdParty.list.forEach(::implementation)
   Lib.Accompanist.list.forEach(::implementation)
@@ -54,7 +54,7 @@ dependencies {
   /*DI*/
   implementation(Lib.Di.hilt)
   implementation(Lib.Di.hiltNavigationCompose)
-  implementation(Lib.Di.viewmodel)
+//  implementation(Lib.Di.viewmodel)
   kapt(Lib.Di.hiltCompiler)
   kapt(Lib.Di.hiltAndroidCompiler)
 

--- a/navigator/src/main/java/com/mutualmobile/praxis/navigator/composenavigator/ComposeNavigator.kt
+++ b/navigator/src/main/java/com/mutualmobile/praxis/navigator/composenavigator/ComposeNavigator.kt
@@ -49,12 +49,12 @@ class PraxisCloneComposeNavigator @Inject constructor(): ComposeNavigator() {
           ?: navController.currentBackStackEntry
 
         backStackEntry?.savedStateHandle?.let { savedStateHandle ->
-          savedStateHandle.getLiveData<T?>(key)
+          savedStateHandle.getLiveData<T>(key)
             .asFlow()
             .filter { it != null }
             .onEach {
               // Nullify the result to avoid resubmitting it
-              savedStateHandle.set(key, null)
+              savedStateHandle[key] = null
             }
         } ?: emptyFlow()
       }

--- a/ui-authentication/build.gradle.kts
+++ b/ui-authentication/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id(BuildPlugins.KOTLIN_KAPT)
     id(BuildPlugins.DAGGER_HILT)
     id(BuildPlugins.KOTLIN_PARCELABLE_PLUGIN)
-    id("org.jlleitschuh.gradle.ktlint")
+    id("org.jlleitschuh.gradle.ktlint") version "11.2.0"
 }
 
 android {
@@ -50,7 +50,6 @@ android {
 
 // Required for annotation processing plugins like Dagger
 kapt {
-    generateStubs = true
     correctErrorTypes = true
 }
 
@@ -65,6 +64,7 @@ dependencies {
     
 
     Lib.Androidx.list.forEach(::implementation)
+    implementation(platform(Lib.Androidx.Compose.COMPOSE_BOM))
     Lib.Androidx.Compose.list.forEach(::implementation)
     Lib.ThirdParty.list.forEach(::implementation)
     Lib.Accompanist.list.forEach(::implementation)
@@ -74,7 +74,7 @@ dependencies {
     /*DI*/
     implementation(Lib.Di.hilt)
     implementation(Lib.Di.hiltNavigationCompose)
-    implementation(Lib.Di.viewmodel)
+//    implementation(Lib.Di.viewmodel)
     kapt(Lib.Di.hiltCompiler)
     kapt(Lib.Di.hiltAndroidCompiler)
 

--- a/ui-onboarding/build.gradle.kts
+++ b/ui-onboarding/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id(BuildPlugins.KOTLIN_KAPT)
     id(BuildPlugins.DAGGER_HILT)
     id(BuildPlugins.KOTLIN_PARCELABLE_PLUGIN)
-    id("org.jlleitschuh.gradle.ktlint")
+    id("org.jlleitschuh.gradle.ktlint") version "11.2.0"
 }
 
 android {
@@ -50,7 +50,6 @@ android {
 
 // Required for annotation processing plugins like Dagger
 kapt {
-    generateStubs = true
     correctErrorTypes = true
 }
 
@@ -66,6 +65,7 @@ dependencies {
 
 
     Lib.Androidx.list.forEach(::implementation)
+    implementation(platform(Lib.Androidx.Compose.COMPOSE_BOM))
     Lib.Androidx.Compose.list.forEach(::implementation)
     Lib.ThirdParty.list.forEach(::implementation)
     Lib.Accompanist.list.forEach(::implementation)
@@ -75,7 +75,7 @@ dependencies {
     /*DI*/
     implementation(Lib.Di.hilt)
     implementation(Lib.Di.hiltNavigationCompose)
-    implementation(Lib.Di.viewmodel)
+//    implementation(Lib.Di.viewmodel)
     kapt(Lib.Di.hiltCompiler)
     kapt(Lib.Di.hiltAndroidCompiler)
 


### PR DESCRIPTION
This PR does the following things

1. Migrated compose to latest Bills of Material
2. Update kotlin to 1.8.10
3. Target Java 11
4. remove `kapt.generateStubs` 
5. Update dagger to 2.45
6. Change target and compile SDK to 33
7. Update accompanist to latest stable
8. Build gradle to latest stable 7.4.1

And some miscellaneous libraries.